### PR TITLE
Add publicPath option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 build
+package-lock.json

--- a/Readme.md
+++ b/Readme.md
@@ -14,6 +14,7 @@ Pre-renders web app into static HTML. Uses headless chrome to pre-render. Crawls
 - With `Preload resources` feature you will get faster first interaction time if your page does do AJAX requests.
 - [Works with webpack 2 code splitting feature](https://github.com/stereobooster/react-snap/issues/5)
 - [Handles sourcemaps](https://github.com/stereobooster/react-snap/issues/4)
+- Supports non-root paths (eg for create-react-app relative paths)
 
 Please note: some features are experimental, but basic prerendering is considered stable enough. API is subject to change before freeze in version `1.0`.
 

--- a/run.js
+++ b/run.js
@@ -1,6 +1,10 @@
 #!/usr/bin/env node
 
+const url = require("url");
 const { run } = require("./index.js");
-const { reactSnap } = require(`${process.cwd()}/package.json`);
+const { reactSnap, homepage } = require(`${process.cwd()}/package.json`);
 
-run(reactSnap);
+run({
+  publicPath: homepage && url.parse(homepage).pathname,
+  ...reactSnap
+});


### PR DESCRIPTION
This is useful for serving the build from a custom path. Useful when links are all prefixed with a basename.

I need this change to make the CRA relative paths work, as shown here: https://github.com/badsyntax/react-snap-example/commit/8b142432325aece920fed6387e866006931d2b66