### PR TITLE
Preserve DOCTYPE

### DIFF
--- a/index.js
+++ b/index.js
@@ -218,12 +218,7 @@ const fixWebpackChunksIssue = ({ page, basePath, asyncJs }) => {
 };
 
 const saveAsHtml = async ({ page, filePath, options, route }) => {
-  const content = await page.evaluate(
-    () => (document.doctype != null
-          ? new XMLSerializer().serializeToString(document.doctype)
-          : "")
-          + document.documentElement.outerHTML,
-  );
+  const content = await page.content();
   const minifiedContent = options.minifyOptions
     ? minify(content, options.minifyOptions)
     : content;

--- a/index.js
+++ b/index.js
@@ -218,7 +218,12 @@ const fixWebpackChunksIssue = ({ page, basePath, asyncJs }) => {
 };
 
 const saveAsHtml = async ({ page, filePath, options, route }) => {
-  const content = await page.evaluate(() => document.documentElement.outerHTML);
+  const content = await page.evaluate(
+    () => (document.doctype != null
+          ? new XMLSerializer().serializeToString(document.doctype)
+          : "")
+          + document.documentElement.outerHTML,
+  );
   const minifiedContent = options.minifyOptions
     ? minify(content, options.minifyOptions)
     : content;


### PR DESCRIPTION
Browsers render content differently whether it’s present or not.

Followed suggestion method: https://github.com/GoogleChrome/puppeteer/issues/331

Signed-off-by: Frédéric Miserey <frederic@none.net>