### PR TITLE
Add an option to exclude pages based in their url paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ const defaultOptions = {
   concurrency: 4,
   viewport: false,
   include: ["/", "/404"],
+  exclude: [],
   removeStyleTags: false,
   removeBlobs: true,
   inlineCss: false, // experimental

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "express": "^4.16.1",
     "express-history-api-fallback": "^2.2.1",
+    "glob-to-regexp": "^0.3.0",
     "highland": "^2.11.1",
     "html-minifier": "^3.5.5",
     "minimalcss": "^0.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -416,6 +416,10 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
 
+glob-to-regexp@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
+
 glob@^7.0.5:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"


### PR DESCRIPTION
Hi @stereobooster. Great project.

I'd like to use this for my project but there are several routes that I need to exclude when I'm generating snapshots. This pr allows a user to exclude routes by listing them in a `exclude` array under the `reactSnap` key in `package.json`. 

Example

```
  "reactSnap": {
     "exclude": [
      "/registration/",
      "/account",
      "/cart/**",
      "/signin/"
     ]
```

Let me know if you'd like to see an changes and if you would be interested in merging this feature.