### PR TITLE
Add 'puppeteerArgs' to options.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -103,6 +103,17 @@ Headless chrome does not fully support WebGL, if you need render it you can use
 "headless": false
 ```
 
+### Containers and other restricted environments
+
+Puppeteer (headless chrome) may fail due to sandboxing issues. To get around this,
+you may use
+
+```
+"puppeteerArgs": ["--no-sandbox", "--disable-setuid-sandbox"]
+```
+
+Read more about [puppeteer troubleshooting.](https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md)
+
 ### Webpack 2+ and dynamic import
 
 If you get following error `Uncaught ReferenceError: webpackJsonp is not defined`, you can use the following hack

--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ const defaultOptions = {
   sourceMaps: false, // experimental
   preloadResources: false,
   headless: true,
+  puppeteerArgs: [],
   userAgent: "ReactSnap",
   saveAs: "html",
   crawl: true,

--- a/src/puppeteer_utils.js
+++ b/src/puppeteer_utils.js
@@ -110,7 +110,8 @@ const crawl = async opt => {
   };
 
   const browser = await puppeteer.launch({
-    headless: options.headless
+    headless: options.headless,
+    args: options.puppeteerArgs
   });
 
   /**


### PR DESCRIPTION
Add custom puppeteer arguments to options. Fixes issue #28 and let's you use this tool in docker containers.