### PR TITLE
Don’t collapse inline tag whitespace

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,6 @@ const defaultOptions = {
     minifyCSS: true,
     collapseBooleanAttributes: true,
     collapseWhitespace: true,
-    collapseInlineTagWhitespace: true,
     decodeEntities: true,
     keepClosingSlash: true,
     sortAttributes: true,


### PR DESCRIPTION
The output from react-snap for a SPA website (e.g. with create-react-app) is great for search engines, but it's also great for restoring some semblance of progressive enhancement. Except for this particular html-minifier option, which degrades readability when a site is viewed without JS enabled (or fatally explodes):

![screen shot 2017-11-17 at 11 15 47 pm](https://user-images.githubusercontent.com/431435/32976868-acf1ebb8-cbee-11e7-8de9-bbbd8692d623.png)

I've just removed it rather than adding an option to adhere to zero-config. Readability and progressive enhancement seem worthy of the extra bytes!