### PR TITLE
The default configuration breaks projects that use SemanticUI.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -176,6 +176,16 @@ If you get an error in a production build, you can use sourcemaps to decode stac
 
 See [#61](https://github.com/stereobooster/react-snap/pull/61)
 
+### Semantic UI
+
+[Semantic UI](https://semantic-ui.com/) is defined over class substrings that contain spaces
+(eg. "three column"). Sorting the class names therefore breaks the styling. To get around this,
+use the following configuration:
+
+```
+"minifyHtml": { "sortClassName": false }
+```
+
 ## Possible improvements
 
 - Improve [preconnect](http://caniuse.com/#feat=link-rel-preconnect), [dns-prefetch](http://caniuse.com/#feat=link-rel-dns-prefetch) functionality, maybe use [media queries](https://developer.mozilla.org/en-US/docs/Web/HTML/Preloading_content). Example: load in small screen - capture all assets, add with a media query for the small screen, load in big screen add the rest of the assets with a media query for the big screen.


### PR DESCRIPTION
This patch explains why it happens and how to get around it.