### PR TITLE
added try/catch around crawl async function

### DIFF
--- a/index.js
+++ b/index.js
@@ -500,160 +500,165 @@ const run = async userOptions => {
   const { http2PushManifest } = options;
   const http2PushManifestItems = {};
 
-  await crawl({
-    options,
-    basePath,
-    publicPath,
-    sourceDir,
-    beforeFetch: async ({ page, route }) => {
-      const {
-        preloadImages,
-        cacheAjaxRequests,
-        preconnectThirdParty
-      } = options;
-      if (
-        preloadImages ||
-        cacheAjaxRequests ||
-        preconnectThirdParty ||
-        http2PushManifest
-      ) {
+  try {
+    await crawl({
+      options,
+      basePath,
+      publicPath,
+      sourceDir,
+      beforeFetch: async ({ page, route }) => {
         const {
-          ajaxCache: ac,
-          http2PushManifestItems: hpm
-        } = preloadResources({
-          page,
-          basePath,
           preloadImages,
           cacheAjaxRequests,
-          preconnectThirdParty,
-          http2PushManifest,
-          ignoreForPreload: options.ignoreForPreload
-        });
-        ajaxCache[route] = ac;
-        http2PushManifestItems[route] = hpm;
-      }
-    },
-    afterFetch: async ({ page, route, browser }) => {
-      const pageUrl = `${basePath}${route}`;
-      if (options.removeStyleTags) await removeStyleTags({ page });
-      if (options.removeScriptTags) await removeScriptTags({ page });
-      if (options.removeBlobs) await removeBlobs({ page });
-      if (options.inlineCss) {
-        const { cssFiles } = await inlineCss({
-          page,
-          pageUrl,
-          options,
-          basePath,
-          browser
-        });
+          preconnectThirdParty
+        } = options;
+        if (
+          preloadImages ||
+          cacheAjaxRequests ||
+          preconnectThirdParty ||
+          http2PushManifest
+        ) {
+          const {
+            ajaxCache: ac,
+            http2PushManifestItems: hpm
+          } = preloadResources({
+            page,
+            basePath,
+            preloadImages,
+            cacheAjaxRequests,
+            preconnectThirdParty,
+            http2PushManifest,
+            ignoreForPreload: options.ignoreForPreload
+          });
+          ajaxCache[route] = ac;
+          http2PushManifestItems[route] = hpm;
+        }
+      },
+      afterFetch: async ({ page, route, browser }) => {
+        const pageUrl = `${basePath}${route}`;
+        if (options.removeStyleTags) await removeStyleTags({ page });
+        if (options.removeScriptTags) await removeScriptTags({ page });
+        if (options.removeBlobs) await removeBlobs({ page });
+        if (options.inlineCss) {
+          const { cssFiles } = await inlineCss({
+            page,
+            pageUrl,
+            options,
+            basePath,
+            browser
+          });
 
-        if (http2PushManifest) {
-          const filesToRemove = cssFiles
-            .filter(file => file.startsWith(basePath))
-            .map(file => file.replace(basePath, ""));
+          if (http2PushManifest) {
+            const filesToRemove = cssFiles
+              .filter(file => file.startsWith(basePath))
+              .map(file => file.replace(basePath, ""));
 
-          for (let i = http2PushManifestItems[route].length - 1; i >= 0; i--) {
-            const x = http2PushManifestItems[route][i];
-            filesToRemove.forEach(fileToRemove => {
-              if (x.link.startsWith(fileToRemove)) {
-                http2PushManifestItems[route].splice(i, 1);
-              }
-            });
+            for (let i = http2PushManifestItems[route].length - 1; i >= 0; i--) {
+              const x = http2PushManifestItems[route][i];
+              filesToRemove.forEach(fileToRemove => {
+                if (x.link.startsWith(fileToRemove)) {
+                  http2PushManifestItems[route].splice(i, 1);
+                }
+              });
+            }
           }
         }
-      }
-      if (options.fixWebpackChunksIssue) {
-        await fixWebpackChunksIssue({
-          page,
-          basePath,
-          http2PushManifest
-        });
-      }
-      if (options.asyncScriptTags) await asyncScriptTags({ page });
-
-      await page.evaluate(ajaxCache => {
-        const snapEscape = (() => {
-          const UNSAFE_CHARS_REGEXP = /[<>\/\u2028\u2029]/g;
-          // Mapping of unsafe HTML and invalid JavaScript line terminator chars to their
-          // Unicode char counterparts which are safe to use in JavaScript strings.
-          const ESCAPED_CHARS = {
-            "<": "\\u003C",
-            ">": "\\u003E",
-            "/": "\\u002F",
-            "\u2028": "\\u2028",
-            "\u2029": "\\u2029"
-          };
-          const escapeUnsafeChars = unsafeChar => ESCAPED_CHARS[unsafeChar];
-          return str => str.replace(UNSAFE_CHARS_REGEXP, escapeUnsafeChars);
-        })();
-        // TODO: as of now it only prevents XSS attack,
-        // but can stringify only basic data types
-        // e.g. Date, Set, Map, NaN won't be handled right
-        const snapStringify = obj => snapEscape(JSON.stringify(obj));
-
-        let scriptTagText = "";
-        if (ajaxCache && Object.keys(ajaxCache).length > 0) {
-          scriptTagText += `window.snapStore=${snapEscape(
-            JSON.stringify(ajaxCache)
-          )};`;
+        if (options.fixWebpackChunksIssue) {
+          await fixWebpackChunksIssue({
+            page,
+            basePath,
+            http2PushManifest
+          });
         }
-        let state;
-        if (
-          window.snapSaveState &&
-          (state = window.snapSaveState()) &&
-          Object.keys(state).length !== 0
-        ) {
-          scriptTagText += Object.keys(state)
-            .map(key => `window["${key}"]=${snapStringify(state[key])};`)
-            .join("");
-        }
-        if (scriptTagText !== "") {
-          const scriptTag = document.createElement("script");
-          scriptTag.type = "text/javascript";
-          scriptTag.text = scriptTagText;
-          const firstScript = Array.from(document.scripts)[0];
-          firstScript.parentNode.insertBefore(scriptTag, firstScript);
-        }
-      }, ajaxCache[route]);
-      delete ajaxCache[route];
-      if (options.fixInsertRule) await fixInsertRule({ page });
-      await fixFormFields({ page });
+        if (options.asyncScriptTags) await asyncScriptTags({ page });
 
-      const routePath = route.replace(publicPath, "");
-      const filePath = path.join(destinationDir, routePath);
-      if (options.saveAs === "html") {
-        await saveAsHtml({ page, filePath, options, route });
-      } else if (options.saveAs === "png") {
-        await saveAsPng({ page, filePath, options, route });
+        await page.evaluate(ajaxCache => {
+          const snapEscape = (() => {
+            const UNSAFE_CHARS_REGEXP = /[<>\/\u2028\u2029]/g;
+            // Mapping of unsafe HTML and invalid JavaScript line terminator chars to their
+            // Unicode char counterparts which are safe to use in JavaScript strings.
+            const ESCAPED_CHARS = {
+              "<": "\\u003C",
+              ">": "\\u003E",
+              "/": "\\u002F",
+              "\u2028": "\\u2028",
+              "\u2029": "\\u2029"
+            };
+            const escapeUnsafeChars = unsafeChar => ESCAPED_CHARS[unsafeChar];
+            return str => str.replace(UNSAFE_CHARS_REGEXP, escapeUnsafeChars);
+          })();
+          // TODO: as of now it only prevents XSS attack,
+          // but can stringify only basic data types
+          // e.g. Date, Set, Map, NaN won't be handled right
+          const snapStringify = obj => snapEscape(JSON.stringify(obj));
+
+          let scriptTagText = "";
+          if (ajaxCache && Object.keys(ajaxCache).length > 0) {
+            scriptTagText += `window.snapStore=${snapEscape(
+              JSON.stringify(ajaxCache)
+            )};`;
+          }
+          let state;
+          if (
+            window.snapSaveState &&
+            (state = window.snapSaveState()) &&
+            Object.keys(state).length !== 0
+          ) {
+            scriptTagText += Object.keys(state)
+              .map(key => `window["${key}"]=${snapStringify(state[key])};`)
+              .join("");
+          }
+          if (scriptTagText !== "") {
+            const scriptTag = document.createElement("script");
+            scriptTag.type = "text/javascript";
+            scriptTag.text = scriptTagText;
+            const firstScript = Array.from(document.scripts)[0];
+            firstScript.parentNode.insertBefore(scriptTag, firstScript);
+          }
+        }, ajaxCache[route]);
+        delete ajaxCache[route];
+        if (options.fixInsertRule) await fixInsertRule({ page });
+        await fixFormFields({ page });
+
+        const routePath = route.replace(publicPath, "");
+        const filePath = path.join(destinationDir, routePath);
+        if (options.saveAs === "html") {
+          await saveAsHtml({ page, filePath, options, route });
+        } else if (options.saveAs === "png") {
+          await saveAsPng({ page, filePath, options, route });
+        }
+      },
+      onEnd: () => {
+        if (server) server.close();
+        if (http2PushManifest) {
+          const manifest = Object.keys(
+            http2PushManifestItems
+          ).reduce((accumulator, key) => {
+            if (http2PushManifestItems[key].length !== 0)
+              accumulator.push({
+                source: key,
+                headers: [
+                  {
+                    key: "Link",
+                    value: http2PushManifestItems[key]
+                      .map(x => `<${x.link}>;rel=preload;as=${x.as}`)
+                      .join(",")
+                  }
+                ]
+              });
+            return accumulator;
+          }, []);
+          fs.writeFileSync(
+            `${destinationDir}/http2-push-manifest.json`,
+            JSON.stringify(manifest)
+          );
+        }
       }
-    },
-    onEnd: () => {
-      if (server) server.close();
-      if (http2PushManifest) {
-        const manifest = Object.keys(
-          http2PushManifestItems
-        ).reduce((accumulator, key) => {
-          if (http2PushManifestItems[key].length !== 0)
-            accumulator.push({
-              source: key,
-              headers: [
-                {
-                  key: "Link",
-                  value: http2PushManifestItems[key]
-                    .map(x => `<${x.link}>;rel=preload;as=${x.as}`)
-                    .join(",")
-                }
-              ]
-            });
-          return accumulator;
-        }, []);
-        fs.writeFileSync(
-          `${destinationDir}/http2-push-manifest.json`,
-          JSON.stringify(manifest)
-        );
-      }
-    }
-  });
+    });
+  } catch (e) {
+    console.log('Exception occurred during crawling.', e);
+    process.exit(1);
+  }
 };
 
 exports.defaultOptions = defaultOptions;

--- a/index.js
+++ b/index.js
@@ -656,8 +656,7 @@ const run = async userOptions => {
       }
     });
   } catch (e) {
-    console.log('Exception occurred during crawling.', e);
-    process.exit(1);
+    return Promise.reject(new Error());
   }
 };
 

--- a/index.js
+++ b/index.js
@@ -656,7 +656,7 @@ const run = async userOptions => {
       }
     });
   } catch (e) {
-    return Promise.reject(new Error());
+    return Promise.reject(new Error(e));
   }
 };
 


### PR DESCRIPTION
I am working on getting react-snap up on my heroku instance and ran into a bug in which puppeteer was not working on the instance. I later found [this issue](https://github.com/stereobooster/react-snap/issues/60) which I am working on implementing now, but the issue I ran into was if puppeteer failed after being called from react-snap, the process would continue to run (as it was unhandled). Here's the error message that I saw (the process would run infinitely in heroku):

<img width="729" alt="screen shot 2018-01-07 at 9 15 24 pm" src="https://user-images.githubusercontent.com/2854919/34657129-3c7059a8-f3f1-11e7-9df6-583a14d9a17a.png">


Therefore I added a `try`/`catch` around the `await crawl` function call and added a `console.log` that throws a generic error message as well as the exception itself. 