### PR TITLE
Fix skipThirdPartyRequests

### DIFF
--- a/src/puppeteer_utils.js
+++ b/src/puppeteer_utils.js
@@ -13,9 +13,9 @@ const fs = require("fs");
 const skipThirdPartyRequests = async opt => {
   const { page, options, basePath } = opt;
   if (!options.skipThirdPartyRequests) return;
-  await page.setRequestInterceptionEnabled(true);
+  await page.setRequestInterception(true);
   page.on("request", request => {
-    if (request.url.startsWith(basePath)) {
+    if (request.url().startsWith(basePath)) {
       request.continue();
     } else {
       request.abort();


### PR DESCRIPTION
There were some changes in the Puppeteer API which broke skipThirdPartyRequests
- `page.setRequestInterceptionEnabled` was renamed `page.setRequestInterception` in [v0.13](https://github.com/GoogleChrome/puppeteer/releases/tag/v0.13.0)
- `request.url` -> `request.url()`