### PR TITLE
Replaced innerText with innerHTML

### DIFF
--- a/index.js
+++ b/index.js
@@ -387,8 +387,8 @@ const fixWebpackChunksIssue = ({ page, basePath, http2PushManifest }) => {
 const fixInsertRule = ({ page }) => {
   return page.evaluate(() => {
     Array.from(document.querySelectorAll("style")).forEach(style => {
-      if (style.innerText === "") {
-        style.innerText = Array.from(style.sheet.rules)
+      if (style.innerHTML === "") {
+        style.innerHTML = Array.from(style.sheet.rules)
           .map(rule => rule.cssText)
           .join("");
       }


### PR DESCRIPTION
Stops newlines being encoded with `<br>` on running `fixInsertRule`. 

Something like
```
@media (min-width: 62em) {
  h1 { font-size: 3.2rem; }
}
```

would get converted to 
```
@media (min-width: 62em) {<br>  h1 { font-size: 3.2rem; }<br>}
```

which in turn would get removed by html-minifier and then not appearing in the final output at all. Setting this via innerHTML should fix this.