### PR TITLE
Add exclude option

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ const defaultOptions = {
   destination: null,
   concurrency: 4,
   include: ["/"],
+  exclude: [],
   userAgent: "ReactSnap",
   // 4 params below will be refactored to one: `puppeteer: {}`
   // https://github.com/stereobooster/react-snap/issues/120

--- a/package.json
+++ b/package.json
@@ -1,8 +1,7 @@
 {
   "name": "react-snap",
   "version": "1.12.2",
-  "description":
-    "Zero-configuration framework-agnostic static prerendering for SPAs",
+  "description": "Zero-configuration framework-agnostic static prerendering for SPAs",
   "main": "index.js",
   "author": "stereobooster",
   "license": "MIT",
@@ -14,6 +13,7 @@
     "clean-css": "^4.1.9",
     "express": "^4.16.1",
     "express-history-api-fallback": "^2.2.1",
+    "glob-to-regexp": "^0.4.0",
     "highland": "^2.11.1",
     "html-minifier": "^3.5.5",
     "minimalcss": "^0.7.5",
@@ -34,7 +34,12 @@
   "bin": {
     "react-snap": "./run.js"
   },
-  "files": ["index.js", "run.js", "src/", "vendor/"],
+  "files": [
+    "index.js",
+    "run.js",
+    "src/",
+    "vendor/"
+  ],
   "reactSnap": {
     "destination": "tmp",
     "inlineCss": true,

--- a/src/puppeteer_utils.js
+++ b/src/puppeteer_utils.js
@@ -1,6 +1,7 @@
 const puppeteer = require("puppeteer");
 const _ = require("highland");
 const url = require("url");
+const glob = require("glob-to-regexp");
 // @ts-ignore
 const mapStackTrace = require("sourcemapped-stacktrace-node").default;
 const path = require("path");
@@ -98,6 +99,7 @@ const crawl = async opt => {
     publicPath,
     sourceDir
   } = opt;
+  const exclude = options.exclude.map(g => glob(g, { extended: true, globstar: true}));
   let shuttingDown = false;
   let streamClosed = false;
   // TODO: this doesn't work as expected
@@ -125,8 +127,9 @@ const crawl = async opt => {
    * @returns {void}
    */
   const addToQueue = newUrl => {
-    const { hostname, search, hash } = url.parse(newUrl);
+    const { hostname, search, hash, pathname } = url.parse(newUrl);
     newUrl = newUrl.replace(`${search || ""}${hash || ""}`, "");
+    if (exclude.filter(regex => regex.test(pathname)).length > 0) return;
     if (hostname === "localhost" && !uniqueUrls.has(newUrl) && !streamClosed) {
       uniqueUrls.add(newUrl);
       enqued++;

--- a/yarn.lock
+++ b/yarn.lock
@@ -400,6 +400,10 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
 
+glob-to-regexp@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.0.tgz#49bd677b1671022bd10921c3788f23cdebf9c7e6"
+
 glob@^7.0.5:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"


### PR DESCRIPTION
Bringing back this PR to allow an option to exclude routes, very useful for dynamic routes.

example: 
```json
"reactSnap": {
    "exclude": [
        "/dynamicRoute/**",
        "/anotherRoute"
    ]
}
```