### PR TITLE
Add sitemap.xml option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -107,6 +107,19 @@ If you need to pass some options for `react-snap`, you can do this in the `packa
 
 All options are not documented yet, but you can check `defaultOptions` in `index.js`.
 
+### Sitemap
+
+If you want to generate a `sitemap.xml` for your static website you can do this in the `package.json`, like this:
+
+```json
+"homepage": "https://mycoolwebsite.com/",
+"reactSnap": {
+  "sitemap": true
+}
+```
+
+Without the `homepage` a sitemap can't be generated.
+
 ### inlineCss
 
 Experimental feature - requires improvements.

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ const fs = require("fs");
 const mkdirp = require("mkdirp");
 const minify = require("html-minifier").minify;
 const url = require("url");
+const { homepage } = require(`${process.cwd()}/package.json`);
 // @ts-ignore https://github.com/peterbe/minimalcss/pull/30
 const minimalcss = require("minimalcss");
 const CleanCSS = require("clean-css");
@@ -21,6 +22,7 @@ const defaultOptions = {
   destination: null,
   concurrency: 4,
   include: ["/"],
+  sitemap: false,
   userAgent: "ReactSnap",
   // 4 params below will be refactored to one: `puppeteer: {}`
   // https://github.com/stereobooster/react-snap/issues/120
@@ -457,6 +459,22 @@ const saveAsPng = ({ page, filePath, options, route }) => {
   return page.screenshot({ path: screenshotPath });
 };
 
+const buildSitemap = routes => {
+  const domain = homepage.replace(/\/$/, '')
+  return `
+    <?xml version="1.0" encoding="UTF-8"?>
+    <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+      ${routes.map(route => `
+        <url>
+          <loc>${domain + route}</loc>
+          <lastmod>${new Date().toISOString().split('T')[0]}</lastmod>
+          <priority>0.5</priority>
+        </url>
+      `).join(' ')}
+    </urlset>
+  `;
+};
+
 const run = async userOptions => {
   const options = defaults(userOptions);
 
@@ -500,8 +518,9 @@ const run = async userOptions => {
   const basePath = `http://localhost:${options.port}`;
   const publicPath = options.publicPath;
   const ajaxCache = {};
-  const { http2PushManifest } = options;
+  const { http2PushManifest, sitemap } = options;
   const http2PushManifestItems = {};
+  const sitemapItems = []
 
   await crawl({
     options,
@@ -514,6 +533,9 @@ const run = async userOptions => {
         cacheAjaxRequests,
         preconnectThirdParty
       } = options;
+
+      if (!route.includes("/404.html")) sitemapItems.push(route)
+
       if (
         preloadImages ||
         cacheAjaxRequests ||
@@ -654,6 +676,20 @@ const run = async userOptions => {
           `${destinationDir}/http2-push-manifest.json`,
           JSON.stringify(manifest)
         );
+      }
+      if (sitemap) {
+        if (!homepage) {
+          console.log('⚠️   To generate a sitemap.xml a domain is required, add homepage to package.json');
+          return;
+        }
+
+        const xml = buildSitemap(sitemapItems);
+
+        fs.writeFileSync(
+          `${destinationDir}/sitemap.xml`,
+          xml.replace(/^\s+/gm, '')
+        );
+        console.log('Sitemap generated!');
       }
     }
   });

--- a/index.js
+++ b/index.js
@@ -9,7 +9,6 @@ const fs = require("fs");
 const mkdirp = require("mkdirp");
 const minify = require("html-minifier").minify;
 const url = require("url");
-const { homepage } = require(`${process.cwd()}/package.json`);
 // @ts-ignore https://github.com/peterbe/minimalcss/pull/30
 const minimalcss = require("minimalcss");
 const CleanCSS = require("clean-css");
@@ -459,7 +458,7 @@ const saveAsPng = ({ page, filePath, options, route }) => {
   return page.screenshot({ path: screenshotPath });
 };
 
-const buildSitemap = routes => {
+const buildSitemap = (routes, homepage) => {
   const domain = homepage.replace(/\/$/, '')
   return `
     <?xml version="1.0" encoding="UTF-8"?>
@@ -534,7 +533,7 @@ const run = async userOptions => {
         preconnectThirdParty
       } = options;
 
-      if (!route.includes("/404.html")) sitemapItems.push(route)
+      if (!route.endsWith("/404.html")) sitemapItems.push(route)
 
       if (
         preloadImages ||
@@ -678,12 +677,12 @@ const run = async userOptions => {
         );
       }
       if (sitemap) {
-        if (!homepage) {
+        if (!options.homepage) {
           console.log('⚠️   To generate a sitemap.xml a domain is required, add homepage to package.json');
           return;
         }
 
-        const xml = buildSitemap(sitemapItems);
+        const xml = buildSitemap(sitemapItems, options.homepage);
 
         fs.writeFileSync(
           `${destinationDir}/sitemap.xml`,

--- a/run.js
+++ b/run.js
@@ -6,5 +6,6 @@ const { reactSnap, homepage } = require(`${process.cwd()}/package.json`);
 
 run({
   publicPath: homepage ? url.parse(homepage).pathname : "/",
+  homepage,
   ...reactSnap
 });


### PR DESCRIPTION
If you want to generate a `sitemap.xml` for your static website you can do this in the `package.json`, like this:

```json
"homepage": "https://mycoolwebsite.com/",
"reactSnap": {
  "sitemap": true
}
```

Without the `homepage` a sitemap can't be generated.
