### PR TITLE
PR: Edits Readme to clarify non-ssr for loadable-components example

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -154,6 +154,7 @@ It is not a problem to render async component with react-snap, tricky part happe
 import { loadComponents, getState } from "loadable-components";
 window.snapSaveState = () => getState();
 
+// For SSR only. If not, omit the following.
 loadComponents().then(() => {
   hydrate(AppWithRouter, rootElement);
 });


### PR DESCRIPTION
Edits README section on loadable-components to clarify that the line 
```js
loadComponents().then(() => {
  hydrate(AppWithRouter, rootElement);
});
```
is for server side rendering only. Without understanding what's going on inside react-snap, this was a pain to solve.

For anybody else running into this in the future, if you are not SSR-ing, all you need to add is 
```js
import { hydrate, render } from 'react-dom';
import { getState } from "loadable-components";
window.snapSaveState = () => getState();

const rootElement = document.getElementById('root');
if (rootElement.hasChildNodes()) {
  hydrate(<App />, rootElement);
} else {
  render(<App />, rootElement);
}
```
which is so great and simple, just not as obvious as it could be.