### PR TITLE
Add support for allowed third party domains

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,6 +50,7 @@ const defaultOptions = {
   removeBlobs: true,
   fixInsertRule: true,
   skipThirdPartyRequests: false,
+  allowedThirdPartyDomains: [],
   cacheAjaxRequests: false,
   http2PushManifest: false,
   // may use some glob solution in the future, if required

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ const defaultOptions = {
   removeBlobs: true,
   fixInsertRule: true,
   skipThirdPartyRequests: false,
-  allowedThirdPartyDomains: [],
+  includedThirdPartyRequests: [],
   cacheAjaxRequests: false,
   http2PushManifest: false,
   // may use some glob solution in the future, if required

--- a/src/puppeteer_utils.js
+++ b/src/puppeteer_utils.js
@@ -10,21 +10,21 @@ const fs = require("fs");
  * @return {Promise<void>}
  */
 const skipThirdPartyRequests = async opt => {
-  const {page, options, basePath} = opt
-  const {skipThirdPartyRequests, allowedThirdPartyDomains} = options
-  if (!skipThirdPartyRequests) return
-  await page.setRequestInterception(true)
-  page.on('request', request => {
-    const url = request.url()
+  const { page, options, basePath } = opt;
+  const { skipThirdPartyRequests, allowedThirdPartyDomains } = options;
+  if (!skipThirdPartyRequests) return;
+  await page.setRequestInterception(true);
+  page.on("request", request => {
+    const url = request.url();
     if (url.startsWith(basePath)) {
-      request.continue()
+      request.continue();
     } else if (allowedThirdPartyDomains.some(d => url.startsWith(d))) {
-      request.continue()
+      request.continue();
     } else {
-      request.abort()
+      request.abort();
     }
-  })
-}
+  });
+};
 
 /**
  * @param {{page: Page, options: {sourceMaps: boolean}, route: string, onError: ?function }} opt

--- a/src/puppeteer_utils.js
+++ b/src/puppeteer_utils.js
@@ -6,21 +6,25 @@ const path = require("path");
 const fs = require("fs");
 
 /**
- * @param {{page: Page, options: {skipThirdPartyRequests: true}, basePath: string }} opt
+ * @param {{page: Page, options: {skipThirdPartyRequests: true, allowedThirdPartyDomains: []}, basePath: string }} opt
  * @return {Promise<void>}
  */
 const skipThirdPartyRequests = async opt => {
-  const { page, options, basePath } = opt;
-  if (!options.skipThirdPartyRequests) return;
-  await page.setRequestInterception(true);
-  page.on("request", request => {
-    if (request.url().startsWith(basePath)) {
-      request.continue();
+  const {page, options, basePath} = opt
+  const {skipThirdPartyRequests, allowedThirdPartyDomains} = options
+  if (!skipThirdPartyRequests) return
+  await page.setRequestInterception(true)
+  page.on('request', request => {
+    const url = request.url()
+    if (url.startsWith(basePath)) {
+      request.continue()
+    } else if (allowedThirdPartyDomains.some(d => url.startsWith(d))) {
+      request.continue()
     } else {
-      request.abort();
+      request.abort()
     }
-  });
-};
+  })
+}
 
 /**
  * @param {{page: Page, options: {sourceMaps: boolean}, route: string, onError: ?function }} opt

--- a/tests/__snapshots__/defaultOptions.test.js.snap
+++ b/tests/__snapshots__/defaultOptions.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`defaultOptions 1`] = `
 Object {
+  "allowedThirdPartyDomains": Array [],
   "asyncScriptTags": false,
   "cacheAjaxRequests": false,
   "concurrency": 4,

--- a/tests/__snapshots__/defaultOptions.test.js.snap
+++ b/tests/__snapshots__/defaultOptions.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`defaultOptions 1`] = `
 Object {
-  "allowedThirdPartyDomains": Array [],
   "asyncScriptTags": false,
   "cacheAjaxRequests": false,
   "concurrency": 4,
@@ -19,6 +18,7 @@ Object {
   "include": Array [
     "/",
   ],
+  "includedThirdPartyRequests": Array [],
   "inlineCss": false,
   "minifyCss": Object {},
   "minifyHtml": Object {

--- a/tests/run.test.js
+++ b/tests/run.test.js
@@ -2,6 +2,8 @@
 // TODO: capture console log from run function
 const { mockFs } = require("./helper.js");
 const { run } = require("./../index.js");
+const { thirdPartyRequestHandler } = require("./../src/puppeteer_utils.js");
+
 const snapRun = (fs, options) =>
   run(
     {
@@ -447,6 +449,50 @@ describe("cacheAjaxRequests", () => {
 describe.skip("publicPath", () => {});
 
 describe.skip("skipThirdPartyRequests", () => {});
+
+describe("thirdPartyRequestHandler", () => {
+  const requestBlueprint = {
+    abort: jest.fn(),
+    continue: jest.fn(),
+    url: () => "https://localhost/data"
+  };
+  afterEach(() => {
+    requestBlueprint.abort.mockClear();
+    requestBlueprint.continue.mockClear();
+  });
+  test("request.continue() is called if url starts with the basePath", () => {
+    const request = {
+      ...requestBlueprint
+    };
+    const basePath = "https://localhost/";
+    const includedThirdPartyRequests = ["https://api.localhost"];
+    thirdPartyRequestHandler(request, basePath, includedThirdPartyRequests);
+    expect(request.continue).toHaveBeenCalledTimes(1);
+    expect(request.abort).toHaveBeenCalledTimes(0);
+  });
+  test("request.continue() is called if url starts with an included third party url", () => {
+    const request = {
+      ...requestBlueprint,
+      url: () => "https://api.localhost/data"
+    };
+    const basePath = "https://localhost/";
+    const includedThirdPartyRequests = ["https://api.localhost"];
+    thirdPartyRequestHandler(request, basePath, includedThirdPartyRequests);
+    expect(request.continue).toHaveBeenCalledTimes(1);
+    expect(request.abort).toHaveBeenCalledTimes(0);
+  });
+  test("request.abort() is called if url is an excluded third party", () => {
+    const request = {
+      ...requestBlueprint,
+      url: () => "https://api.localhost/data"
+    };
+    const basePath = "https://localhost/";
+    const includedThirdPartyRequests = [];
+    thirdPartyRequestHandler(request, basePath, includedThirdPartyRequests);
+    expect(request.continue).toHaveBeenCalledTimes(0);
+    expect(request.abort).toHaveBeenCalledTimes(1);
+  });
+});
 
 describe.skip("waitFor", () => {});
 


### PR DESCRIPTION
With `skipThirdPartyRequests: true`, calls to our own APIs are blocked too . I added an `allowedThirdPartyDomains` array to the `options` config, to act as a whitelist. 

Example usage:
```json
// package.json
"reactSnap": {
  "skipThirdPartyRequests": true,
  "allowedThirdPartyDomains": ["https://api.pizzahut.io"]
}
```

Any request url starting with https://api.pizzahut.io will _not_ be skipped, e.g.
https://api.pizzahut.io/v1/huts/?sector=uk-1,uk-2

---

We love using `react-snap` on https://www.pizzahut.co.uk/ and https://www.pizzahut.fr/. Thank you so much for your work, @stereobooster.


