### PR TITLE
Use process.env.PUBLIC_URL when available

### DIFF
--- a/run.js
+++ b/run.js
@@ -4,8 +4,10 @@ const url = require("url");
 const { run } = require("./index.js");
 const { reactSnap, homepage } = require(`${process.cwd()}/package.json`);
 
+const publicUrl = process.env.PUBLIC_URL || homepage;
+
 run({
-  publicPath: homepage ? url.parse(homepage).pathname : "/",
+  publicPath: publicUrl ? url.parse(publicUrl).pathname : "/",
   ...reactSnap
 }).catch((error) => {
   console.error(error)


### PR DESCRIPTION
Right now, `react-snap` relies on the `homepage` field of the app's package.json (or `reactSnap.publicPath`). In some cases though, we need to infer the public URL dynamically from the environment. This feature exists in CRA but not in `react-snap`. 

The purpose of this PR is to use `process.env.PUBLIC_URL` (when available) instead of `homepage`. If `process.env.PUBLIC_URL` is not provided, then `react-snap` will work just as it did before, falling back to `homepage`.

It's basically the same logic as in create-react-app https://github.com/facebook/create-react-app/blob/61c864c38a2313f27f7ed89e70c78f982a688b9a/packages/react-scripts/config/paths.js#L46

Btw, thank you @stereobooster for this package!