### PR TITLE
Fixed potential error where head does not exist in doc

### DIFF
--- a/index.js
+++ b/index.js
@@ -334,7 +334,7 @@ const inlineCss = async opt => {
         style = document.createElement("style");
       style.type = "text/css";
       style.appendChild(document.createTextNode(allCss));
-      head && head.appendChild(style);
+      head.appendChild(style);
 
       const stylesheets = Array.from(
         document.querySelectorAll("link[rel=stylesheet]")

--- a/index.js
+++ b/index.js
@@ -330,10 +330,17 @@ const inlineCss = async opt => {
     );
   } else {
     await page.evaluate(allCss => {
+      if (!allCss)
+        return;
+
       const head = document.head || document.getElementsByTagName("head")[0],
         style = document.createElement("style");
       style.type = "text/css";
       style.appendChild(document.createTextNode(allCss));
+
+      if (!head) 
+        throw "No <head> element found in document";
+
       head.appendChild(style);
 
       const stylesheets = Array.from(

--- a/index.js
+++ b/index.js
@@ -334,7 +334,7 @@ const inlineCss = async opt => {
         style = document.createElement("style");
       style.type = "text/css";
       style.appendChild(document.createTextNode(allCss));
-      head.appendChild(style);
+      head && head.appendChild(style);
 
       const stylesheets = Array.from(
         document.querySelectorAll("link[rel=stylesheet]")

--- a/tests/examples/partial/index.html
+++ b/tests/examples/partial/index.html
@@ -1,0 +1,1 @@
+<script src="./index.js"></script>

--- a/tests/examples/partial/index.js
+++ b/tests/examples/partial/index.js
@@ -1,0 +1,11 @@
+if (navigator.userAgent === "ReactSnap") {
+    // Strip out all content except the root
+    while (document.firstChild)
+        document.removeChild(document.firstChild);
+
+    let div = document.createElement("div");
+    div.className = `root`;
+    div.innerHTML = `This is my content`;
+
+    document.appendChild(div);
+}

--- a/tests/run.test.js
+++ b/tests/run.test.js
@@ -214,6 +214,16 @@ describe("inlineCss - big file", () => {
   });
 });
 
+describe("inlineCss - partial document", () => {
+  const source = "tests/examples/partial";
+  const { fs, filesCreated, content } = mockFs();
+  beforeAll(() => snapRun(fs, { source, inlineCss: true }));
+  test("no inline style", () => {
+    expect(filesCreated()).toEqual(1);
+    expect(content(0)).not.toMatch('<style type="text/css">');
+  });
+});
+
 describe("removeBlobs", () => {
   const source = "tests/examples/other";
   const include = ["/remove-blobs.html"];


### PR DESCRIPTION
This issue occurred when I was doing some transformations to certain pages to generate partial static HTML snippits for inclusion via ajax; react-snap would fail because the <head> element doesnt exist
