### PR TITLE
Fixed SVG Links

### DIFF
--- a/src/puppeteer_utils.js
+++ b/src/puppeteer_utils.js
@@ -91,7 +91,12 @@ const enableLogging = opt => {
 const getLinks = async opt => {
   const { page } = opt;
   const anchors = await page.evaluate(() =>
-    Array.from(document.querySelectorAll("a")).map(anchor => anchor.href)
+    Array.from(document.querySelectorAll("a")).map(anchor => {
+      if(anchor.href.baseVal){
+        return location.origin + anchor.href.baseVal;
+      }
+      return anchor.href
+    })
   );
 
   const iframes = await page.evaluate(() =>


### PR DESCRIPTION
Running react-snap with inline SVG Links throws an error. Cauz anchor.href returns {baseVal:'string', animVal:'string'} and react-snap expected a string instead of an object