### PR TITLE
Allow configuration file path to be passed via postbuild script

### DIFF
--- a/.reactsnaprc.js
+++ b/.reactsnaprc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  test: 'it worked!',
+}

--- a/.reactsnaprc.js
+++ b/.reactsnaprc.js
@@ -1,3 +1,0 @@
-module.exports = {
-  test: 'it worked!',
-}

--- a/run.js
+++ b/run.js
@@ -1,15 +1,46 @@
 #!/usr/bin/env node
 
-const url = require("url");
-const { run } = require("./index.js");
-const { reactSnap, homepage } = require(`${process.cwd()}/package.json`);
+const url = require('url')
+const {run} = require('./index.js')
+const {join} = require('path')
 
-const publicUrl = process.env.PUBLIC_URL || homepage;
+const rootDirectory = process.cwd()
+const {reactSnap, homepage} = require(join(rootDirectory, 'package.json'))
+
+const publicUrl = process.env.PUBLIC_URL || homepage
+
+const load = pathOrModule => {
+  try {
+    return require(pathOrModule)
+  } catch (e) {
+    return null
+  }
+}
+
+let config = reactSnap
+
+if (!reactSnap) {
+  const results = process.argv.filter(s => s.split('=')[0] === '--config')
+  const [match] = results
+  const [, configPath] = match.split('=')
+
+  if (configPath) {
+    config = load(configPath) || load(join(rootDirectory, configPath))
+  } else {
+    !configFile &&
+      console.log(
+        'Must specify configuration field in package.json, or config file path with --config flag in your postbuild script',
+      )
+    process.exit(1)
+  }
+}
+
+console.log(config)
 
 run({
-  publicPath: publicUrl ? url.parse(publicUrl).pathname : "/",
-  ...reactSnap
-}).catch((error) => {
+  publicPath: publicUrl ? url.parse(publicUrl).pathname : '/',
+  ...reactSnap,
+}).catch(error => {
   console.error(error)
-  process.exit(1);
-});
+  process.exit(1)
+})


### PR DESCRIPTION
Hi,

I'm working on a tool that applies react-snap configuration at runtime. At first, I tried monkeypatching `package.json`, but that was a no-go (since the instance is already-running, it can't be swapped out through require.cache). With this PR, you should be able to place react-snap configuration inside of a file (absolute, in node_modules or relative the root directory––should work all the same), and then reference that configuration file in the postbuild script:

```diff
"scripts": {
- "postbuild": "react-snap",
+ "postbuild": "react-snap --config=.react-snaprc.json"
}
```

One benefit of this is that you could create and publish default configurations for common environments like CRA. That way, people could configure react-snap with even less config!!!

Please make sure to test it out for yourself incase I'm overlooking anything architecturally. I'm really hoping this passes through! It would make my life a lot easier (no pressure though ;).

Thanks,

Harry