### PR TITLE
Null check pkg devDependancies and dependancies

### DIFF
--- a/run.js
+++ b/run.js
@@ -12,7 +12,8 @@ const {
 const publicUrl = process.env.PUBLIC_URL || homepage;
 
 const reactScriptsVersion = parseInt(
-  devDependencies["react-scripts"] || dependencies["react-scripts"]
+  (devDependencies && devDependencies["react-scripts"]) 
+  || (dependencies && dependencies["react-scripts"])
 );
 let fixWebpackChunksIssue;
 switch (reactScriptsVersion) {


### PR DESCRIPTION
This throws if you do not have any devDependancies (related to the cra2 fix).
```
/node_modules/react-snap/run.js:15
  devDependencies["react-scripts"] || dependencies["react-scripts"]
                 ^

TypeError: Cannot read property 'react-scripts' of undefined
```

Added null checking to both dep objects. Although we are not handling a non-resolved int, I don't think that's important now.