### PR TITLE
Use react-prerendered-component to solve code splitting flash

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -192,18 +192,16 @@ This library could _keep_ the pre-rendered HTML until codesplitted part is not l
 ```js
 import {PrerenderedComponent} from 'react-prerendered-component';
 
-// using react-loadable
-const AsyncLoadedComponent = loadable(() => import('./deferredComponent'));
-// using react-imported-component
-const AsyncLoadedComponent = imported(() => import('./deferredComponent'));
+const AsyncLoadedComponent = someLibrary(() => import('./deferredComponent'));
 
 <PrerenderedComponent
-  live={AsyncLoadedComponent.preload()}
+  live={AsyncLoadedComponent.preload()} // for react-loadable or react-imported-component
+  live={AsyncLoadedComponent.requireAsync()} // for @loadable/components (not official way)
 >
   <AsyncLoadedComponent />
 </PrerenderedComponent>
 ```
-Until `import promise` would not resolved - it would display content, react-snap pre-rendered for you.
+Until `import promise` would not resolved - it would display content, react-snap have pre-rendered for you.
 
 The same apporoach would work with `React.lazy`, but it does not support `prefetch`, so you will have to do it yourself (fragile!).
 ```js
@@ -221,7 +219,6 @@ const AsyncLoadedComponent = React.lazy(() => import('./deferredComponent'));
 >
   <AsyncLoadedComponent />
 </PrerenderedComponent>
-
 ```
 
 ### Redux

--- a/Readme.md
+++ b/Readme.md
@@ -196,7 +196,7 @@ const AsyncLoadedComponent = someLibrary(() => import('./deferredComponent'));
 
 <PrerenderedComponent
   live={AsyncLoadedComponent.preload()} // for react-loadable or react-imported-component
-  live={AsyncLoadedComponent.requireAsync()} // for @loadable/components (not official way)
+  live={AsyncLoadedComponent.load()} // for @loadable/components (not official way)
 >
   <AsyncLoadedComponent />
 </PrerenderedComponent>


### PR DESCRIPTION
The flash of unloaded content is a big pain of react-snap.

Loadable components were the only library it can work with, but you are no longer besties.

[Prerendered-component](https://github.com/theKashey/react-prerendered-component) could solve the issue for react-loadable, and any other library with "prefetch". Loadable-components does not support this feature officially, but [there are ways](https://github.com/smooth-code/loadable-components/pull/226)...

Also adding a code sample to make snap React.lazy compatible (with some level of hacks)

I am already using preloaded with react-snap and it's working just seamlessly, and hope you users would also happy to use it.