### PR TITLE
minimalcss to use its own puppeteer.launch

### DIFF
--- a/index.js
+++ b/index.js
@@ -271,7 +271,7 @@ const inlineCss = async opt => {
     urls: [pageUrl],
     skippable: request =>
       options.skipThirdPartyRequests && !request.url().startsWith(basePath),
-    browser: browser,
+    // browser: browser,
     userAgent: options.userAgent
   });
   const criticalCss = minimalcssResult.finalCss;

--- a/src/puppeteer_utils.js
+++ b/src/puppeteer_utils.js
@@ -211,7 +211,8 @@ const crawl = async opt => {
     if (!shuttingDown && !skipExistingFile) {
       try {
         const page = await browser.newPage();
-        await page._client.send("ServiceWorker.disable");
+        // await page._client.send("ServiceWorker.disable");
+    
         await page.setCacheEnabled(options.puppeteer.cache);
         if (options.viewport) await page.setViewport(options.viewport);
         if (options.skipThirdPartyRequests)


### PR DESCRIPTION
Letting minimalcss use a  different instance of puppeteer than react-snap.

referring to #314  , it says there
"Do the same as minimalcss peterbe/minimalcss#223"

If I got it correct they removed service workers to solve puppeteer's "cannot read property 'ok' of null" issue. 
so if we want react-snap to use service workers, then minimalcss should use it's own puppeteer instance that includes their solution that is probably not using service workers. 
