### PR TITLE
Fixes #212, check url port before crawling

### DIFF
--- a/src/puppeteer_utils.js
+++ b/src/puppeteer_utils.js
@@ -173,9 +173,17 @@ const crawl = async opt => {
    * @returns {void}
    */
   const addToQueue = newUrl => {
-    const { hostname, search, hash } = url.parse(newUrl);
+    const { hostname, search, hash, port } = url.parse(newUrl);
     newUrl = newUrl.replace(`${search || ""}${hash || ""}`, "");
-    if (hostname === "localhost" && !uniqueUrls.has(newUrl) && !streamClosed) {
+
+    // Ensures that only link on the same port are crawled
+    //
+    // url.parse returns a string,
+    // but options port is passed by a user and default value is a number
+    // we are converting both to string to be sure
+    const isOnAppPort = port.toString() === options.port.toString();
+
+    if (hostname === "localhost" && isOnAppPort && !uniqueUrls.has(newUrl) && !streamClosed) {
       uniqueUrls.add(newUrl);
       enqued++;
       queue.write(newUrl);

--- a/tests/examples/other/404.html
+++ b/tests/examples/other/404.html
@@ -1,0 +1,12 @@
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <title>404</title>
+</head>
+
+<body>
+  404 dummy file
+</body>
+
+</html>

--- a/tests/examples/other/localhost-links-different-port.html
+++ b/tests/examples/other/localhost-links-different-port.html
@@ -1,0 +1,12 @@
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+</head>
+
+<body>
+  <a href="http://localhost:55555">localhost link on a different port</a>
+  <a href="index.html">html</a>
+</body>
+
+</html>

--- a/tests/examples/other/localhost-links-different-port.html
+++ b/tests/examples/other/localhost-links-different-port.html
@@ -6,7 +6,6 @@
 
 <body>
   <a href="http://localhost:55555">localhost link on a different port</a>
-  <a href="index.html">html</a>
 </body>
 
 </html>

--- a/tests/run.test.js
+++ b/tests/run.test.js
@@ -508,6 +508,28 @@ describe("cacheAjaxRequests", () => {
   });
 });
 
+describe("don't crawl localhost links on different port", () => {
+  const source = "tests/examples/other";
+  const include = ["/localhost-links-different-port.html"];
+  
+  const { fs, filesCreated, names } = mockFs();
+
+  beforeAll(() => snapRun(fs, { source, include }));
+  test("three files are crawled", () => {
+    console.log(names());
+    expect(filesCreated()).toEqual(3);
+    expect(names()).toEqual(
+      expect.arrayContaining([
+        `/${source}/localhost-links-different-port.html`,
+        `/${source}/404.html`,
+        `/${source}/index.html`
+      ])
+    );
+  });
+  
+});
+
+
 describe("svgLinks", () => {
   const source = "tests/examples/other";
   const include = ["/svg.html"];

--- a/tests/run.test.js
+++ b/tests/run.test.js
@@ -520,7 +520,7 @@ describe("don't crawl localhost links on different port", () => {
     expect(names()).toEqual(
       expect.arrayContaining([
         `/${source}/localhost-links-different-port.html`
-      ]);
+      ])
     );
   });
   

--- a/tests/run.test.js
+++ b/tests/run.test.js
@@ -515,15 +515,12 @@ describe("don't crawl localhost links on different port", () => {
   const { fs, filesCreated, names } = mockFs();
 
   beforeAll(() => snapRun(fs, { source, include }));
-  test("three files are crawled", () => {
-    console.log(names());
-    expect(filesCreated()).toEqual(3);
+  test("only one file is crawled", () => {
+    expect(filesCreated()).toEqual(1);
     expect(names()).toEqual(
       expect.arrayContaining([
-        `/${source}/localhost-links-different-port.html`,
-        `/${source}/404.html`,
-        `/${source}/index.html`
-      ])
+        `/${source}/localhost-links-different-port.html`
+      ]);
     );
   });
   


### PR DESCRIPTION
### Description

Made sure that before adding url to the queue, link's port matches the application port.

I converted both ports to string, to be sure, as the one in options is a number, but the parsed one is a string.

Fixes #212 
