### PR TITLE
Added 'onJsonFetch' callback option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -127,6 +127,33 @@ If you need to pass some options for `react-snap`, you can do this in your `pack
 
 Not all options are documented yet, but you can check `defaultOptions` in `index.js`.
 
+### Callbacks
+
+* `onJsonFetch` 
+
+  Called every time JSON file is fetched.
+  
+  It needs to be a string, path to the file which contains a callback function. Function needs to be file's default export. 
+
+  Example usage in package json:
+
+  ```json
+  "reactSnap": {
+    "onJsonFetch": "./callbacks/on-json-fetch.js"
+  }
+  ```
+
+  Example of the script:
+
+  ```js
+  function onJsonFetch(json) {
+    console.log('onJsonFetch callback', json);
+  }
+
+  module.exports = onJsonFetch;
+  ```
+
+
 ### inlineCss
 
 Experimental feature - requires improvements.

--- a/tests/__snapshots__/defaultOptions.test.js.snap
+++ b/tests/__snapshots__/defaultOptions.test.js.snap
@@ -28,6 +28,7 @@ Object {
     "sortAttributes": true,
     "sortClassName": false,
   },
+  "onJsonFetch": null,
   "port": 45678,
   "preconnectThirdParty": true,
   "preloadImages": false,

--- a/tests/examples/callbacks/on-json-fetch.js
+++ b/tests/examples/callbacks/on-json-fetch.js
@@ -1,0 +1,5 @@
+function onJsonFetch(route, json) {
+  console.log('onJsonFetch callback', route, json);
+}
+
+module.exports = onJsonFetch;

--- a/tests/examples/callbacks/on-snap-save-state.js
+++ b/tests/examples/callbacks/on-snap-save-state.js
@@ -1,0 +1,5 @@
+function onSnapSaveState(state) {
+  console.log('onSnapSaveState callback', state);
+}
+
+module.exports = onSnapSaveState;

--- a/tests/run.test.js
+++ b/tests/run.test.js
@@ -508,6 +508,26 @@ describe("cacheAjaxRequests", () => {
   });
 });
 
+describe("onFetchJson", () => {
+  const source = "tests/examples/other";
+  const include = ["/ajax-request.html"];
+  const { fs, filesCreated, content } = mockFs();
+
+  beforeAll(() => snapRun(fs, { 
+    source, 
+    include, 
+    onJsonFetch: './tests/examples/callbacks/on-json-fetch.js'
+  }));
+
+  jest.spyOn(global.console, 'log');
+
+  test("on json fetch callback is called", () => {
+    expect(filesCreated()).toEqual(1);
+    // make sure console.log in on-json-fetch.js is called
+    expect(console.log).toBeCalledWith('onJsonFetch callback', '/js/test.json', { 'test': 1 });
+  });
+});
+
 describe("don't crawl localhost links on different port", () => {
   const source = "tests/examples/other";
   const include = ["/localhost-links-different-port.html"];


### PR DESCRIPTION
I added `onJsonFetch` callback option, which will be called every time JSON file is fetched.

This will allow users to cache json files on file system and create gatsby-like system, where everything, including json data is static.

Relates to [issue #221](https://github.com/stereobooster/react-snap/issues/221).I left a question there some time ago, and finally got some time to implement it.

Let me know what do you think.

-----

* `onJsonFetch` 

  Called every time JSON file is fetched, with `route` and `json` passed to it.
  
  It needs to be a string, path to the file which contains a callback function. Function needs to be file's default export. 

  Example usage in package json:

  ```json
  "reactSnap": {
    "onJsonFetch": "./callbacks/on-json-fetch.js"
  }
  ```

  Example of the script:

  ```js
  function onJsonFetch(route, json) {
    console.log('onJsonFetch callback', route, json);
  }

  module.exports = onJsonFetch;
  ```

