### PR TITLE
Added null check for link port

### DIFF
--- a/src/puppeteer_utils.js
+++ b/src/puppeteer_utils.js
@@ -181,7 +181,8 @@ const crawl = async opt => {
     // url.parse returns a string,
     // but options port is passed by a user and default value is a number
     // we are converting both to string to be sure
-    const isOnAppPort = port.toString() === options.port.toString();
+    // Port can be null, therefore we need the null check
+    const isOnAppPort = port && port.toString() === options.port.toString();
 
     if (hostname === "localhost" && isOnAppPort && !uniqueUrls.has(newUrl) && !streamClosed) {
       uniqueUrls.add(newUrl);

--- a/tests/examples/other/localhost-links-different-port.html
+++ b/tests/examples/other/localhost-links-different-port.html
@@ -6,6 +6,7 @@
 
 <body>
   <a href="http://localhost:55555">localhost link on a different port</a>
+  <a href="http://localhost">localhost link with no port</a>
 </body>
 
 </html>


### PR DESCRIPTION
Bugfix for the issue I introduced in this pr:
https://github.com/stereobooster/react-snap/pull/373

When localhost link has no port, it is returned as `null` and `toString` method fails. Updated test as well.