### PR TITLE
Fix component name typo in Readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -200,7 +200,7 @@ const prefetchLazy = LazyComponent => {
 const prerenderedLazy = dynamicImport => {
   const LazyComponent = React.lazy(dynamicImport);
   return React.memo(props => (
-    <PrerenderedComponent live={prefetchLazy(AsyncLoadedComponent)}>
+    <PrerenderedComponent live={prefetchLazy(LazyComponent)}>
       <LazyComponent {...props} />
     </PrerenderedComponent>
   ));


### PR DESCRIPTION
### Description
The current `AsyncLoadedComponent` is not referenced in the entire readme, and the `prefetchLazy` argument name is `LazyComponent`, so I assume this was a typo.