### PR TITLE
Added new option to disable page skipping on page error.

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,7 +74,11 @@ const defaultOptions = {
   //# another feature creep
   // tribute to Netflix Server Side Only React https://twitter.com/NetflixUIE/status/923374215041912833
   // but this will also remove code which registers service worker
-  removeScriptTags: false
+  removeScriptTags: false,
+  //# another feature creep
+  // sometimes errors on the page should be ignored and not skipped for things
+  // like external scripts that may error even if the page is fine
+  ignorePageErrors: false
 };
 
 /**

--- a/src/puppeteer_utils.js
+++ b/src/puppeteer_utils.js
@@ -230,7 +230,9 @@ const crawl = async opt => {
           options,
           route,
           onError: () => {
-            shuttingDown = true;
+            if(!options.ignorePageErrors){
+              shuttingDown = true;
+            }
           },
           sourcemapStore
         });


### PR DESCRIPTION
### Description
As far as I can tell, `react-snap` ignores pages when there is an error that is thrown. While this is a smart default, there are times when errors being thrown are the result of an external script the developer is not responsible for. In these cases, there should be an option to ignore those errors and take a snapshot of the page anyway.

For example, in our newsroom we have to load ad-tech code (or ads themselves) that can sometimes throw errors. These errors are not our concern as long as the main content loads correctly. But without the option provided in this pull request that would not be possible.

Let me know if you have any questions.

Thanks!