### PR TITLE
Support relative links

### DIFF
--- a/doc/recipes.md
+++ b/doc/recipes.md
@@ -82,6 +82,7 @@ module.exports = {
     "build/index.html"
   ],
   stripPrefix: "build",
+  // relative paths like this will rewrite href and src links as relative links
   publicPath: ".",
   // there is "reactSnap.include": ["/shell.html"] in package.json
   navigateFallback: "/shell.html",

--- a/run.js
+++ b/run.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-const url = require("url");
 const { run } = require("./index.js");
 const {
   reactSnap,
@@ -39,7 +38,7 @@ if (parcel) {
 }
 
 run({
-  publicPath: publicUrl ? url.parse(publicUrl).pathname : "/",
+  publicPath: publicUrl,
   fixWebpackChunksIssue,
   ...reactSnap
 }).catch(error => {


### PR DESCRIPTION
### Description

This change allows react-snap to write relative links to `href` and `src` attributes. It addresses the request in #397, and by happenstance resolves #153.

It accomplishes this by:

1. Detecting the desire for relative links by checking `options.publicPath` for a leading dot (`.`) or explicitly using `options.useRelativeLinks`.
2. Rewriting the public path using `url.URL` to avoid adding more RegExp logic (`url.URL` is used over the `URL` global for Node 8+ compatibility). This part happenstance resolves #153.
3. When relative links are enabled, it traverses elements with `[href^="/"]`, `[href^="./"]`, `[src^="/"]`, and `[src^="./"]`, and replaces it with closest relative version.