### PR TITLE
Update mkdirp to fix minimist vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "highland": "2.13.4",
     "html-minifier": "4.0.0",
     "minimalcss": "0.8.2",
-    "mkdirp": "0.5.1",
+    "mkdirp": "^0.5.3",
     "puppeteer": "^1.8.0",
     "serve-static": "1.14.1",
     "sourcemapped-stacktrace-node": "2.1.8"


### PR DESCRIPTION
### Description

`mkdirp` has been updated to version `0.5.3`

https://github.com/isaacs/node-mkdirp/issues/7#issuecomment-600231795

This addresses this prototype pollution vulnerability in `minimist`:

https://app.snyk.io/vuln/SNYK-JS-MINIMIST-559764
