### PR TITLE
Adds fastFail setting for flaky pages that aren't important

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,8 @@ const defaultOptions = {
   destination: null,
   concurrency: 4,
   include: ["/"],
+  // If you get a Timeout error, ignore and move on
+  fastFail: true,
   userAgent: "ReactSnap",
   // 4 params below will be refactored to one: `puppeteer: {}`
   // https://github.com/stereobooster/react-snap/issues/120

--- a/src/puppeteer_utils.js
+++ b/src/puppeteer_utils.js
@@ -241,7 +241,11 @@ const crawl = async opt => {
           await page.goto(pageUrl, { waitUntil: "networkidle0" });
         } catch (e) {
           e.message = augmentTimeoutError(e.message, tracker);
-          throw e;
+          if (opt.fastFail) {
+            throw e;
+          } else {
+            console.log(`🔥  failed to crawl page: ${pageUrl}`, e);
+          }
         } finally {
           tracker.dispose();
         }


### PR DESCRIPTION
### Description

There's a lot of people reporting Timeout errors, and if they're like me, they'd like to allow react-snap to crawl most of their site regardless of a couple weird page errors.

We have an app with a few hundred pages, and like, 2 of them are flaky. This allows those errors to be ignored, so we can build 99% of our pages.

💔Thank you for all your hard work on this lib!