### PR TITLE
Add Puppeteer Settings

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,10 @@ const defaultOptions = {
   puppeteerArgs: [],
   puppeteerExecutablePath: undefined,
   puppeteerIgnoreHTTPSErrors: false,
+  // this will be merged into browser.launch
+  // see https://pptr.dev/#?product=Puppeteer&version=v5.5.0&show=api-puppeteerlaunchoptions
+  // for all options
+  puppeteerSettings: {},
   publicPath: "/",
   minifyCss: {},
   minifyHtml: {

--- a/src/puppeteer_utils.js
+++ b/src/puppeteer_utils.js
@@ -199,7 +199,8 @@ const crawl = async opt => {
     args: options.puppeteerArgs,
     executablePath: options.puppeteerExecutablePath,
     ignoreHTTPSErrors: options.puppeteerIgnoreHTTPSErrors,
-    handleSIGINT: false
+    handleSIGINT: false,
+    ...options.puppeteerSettings
   });
 
   /**
@@ -238,7 +239,7 @@ const crawl = async opt => {
         await page.setUserAgent(options.userAgent);
         const tracker = createTracker(page);
         try {
-          await page.goto(pageUrl, { waitUntil: "networkidle0" });
+          await page.goto(pageUrl, { waitUntil: options.puppeteerSettings["waitUntil"] || "networkidle0" });
         } catch (e) {
           e.message = augmentTimeoutError(e.message, tracker);
           throw e;


### PR DESCRIPTION
<!--

If this a new feature make sure you discussed it before, otherwise it can stay unmerged for a long time. Check current roadmap https://github.com/stereobooster/react-snap/issues/90

Please add tests for your code.

Just a reminder that you can install your fork via git, to do this you need to add the following to package JSON

{
  "dependencies": {
    "react-snap": "https://github.com/<name>/react-snap.git"
  }
}

You can specify a version:

{
  "dependencies": {
    "react-snap": "https://github.com/<name>/react-snap.git#<branch or tag or commit sha>"
  }
}

--->

### Description
Puppeteer Browser Settings - adding ability to set puppeteer browser options from package json. Example use case: firestore cli keeps an open socket connection, need to set waitUntil to networkidle2 to prevent error precompiling files ( + needed devtools option set to true to be able to debug network connection in non-headless browser to figure out network issues ). This pull will incorporate https://pptr.dev/#?product=Puppeteer&version=v5.5.0&show=api-puppeteerlaunchoptions 

💔Thank you!