### PR TITLE
add ajax whitelist domain option to make calls even if skip third party is turned on

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const crawl = require("./src/puppeteer_utils.js").crawl;
+const isWhitelisted = require("./src/puppeteer_utils.js").isWhitelisted;
 const http = require("http");
 const express = require("express");
 const serveStatic = require("serve-static");
@@ -51,6 +52,7 @@ const defaultOptions = {
   removeBlobs: true,
   fixInsertRule: true,
   skipThirdPartyRequests: false,
+  ajaxDomainWhitelist: [], // will be allowed to make requests even if skipThirdPartyRequests is true
   cacheAjaxRequests: false,
   http2PushManifest: false,
   // may use some glob solution in the future, if required
@@ -270,7 +272,7 @@ const inlineCss = async opt => {
   const minimalcssResult = await minimalcss.minimize({
     urls: [pageUrl],
     skippable: request =>
-      options.skipThirdPartyRequests && !request.url().startsWith(basePath),
+      options.skipThirdPartyRequests && !isWhitelisted(request.url(), options.ajaxDomainWhitelist) && !request.url().startsWith(basePath),
     browser: browser,
     userAgent: options.userAgent
   });

--- a/src/puppeteer_utils.js
+++ b/src/puppeteer_utils.js
@@ -11,6 +11,8 @@ const errorToString = jsHandle =>
 
 const objectToJson = jsHandle => jsHandle.jsonValue();
 
+const isWhitelisted = (url, ajaxDomainWhitelist) => ajaxDomainWhitelist.reduce((allow, domain) => allow || url.startsWith(domain), false);
+
 /**
  * @param {{page: Page, options: {skipThirdPartyRequests: true}, basePath: string }} opt
  * @return {Promise<void>}
@@ -20,7 +22,7 @@ const skipThirdPartyRequests = async opt => {
   if (!options.skipThirdPartyRequests) return;
   await page.setRequestInterception(true);
   page.on("request", request => {
-    if (request.url().startsWith(basePath)) {
+    if (request.url().startsWith(basePath) || isWhitelisted(request.url(), options.ajaxDomainWhitelist)) {
       request.continue();
     } else {
       request.abort();
@@ -294,3 +296,4 @@ exports.skipThirdPartyRequests = skipThirdPartyRequests;
 exports.enableLogging = enableLogging;
 exports.getLinks = getLinks;
 exports.crawl = crawl;
+exports.isWhitelisted = isWhitelisted;


### PR DESCRIPTION
Right now all requests are blocked if `skipThirdPartyRequests` is set to `true`. Added `ajaxDomainWhitelist` option to specify list of domains which will be allowed even if `skipThirdPartyRequests` is `true`. Allows to make ajax calls to our own api's while blocking third party libraries/scripts