### PR TITLE
Propagate minifyCss options to the minimalcss

### DIFF
--- a/index.js
+++ b/index.js
@@ -272,7 +272,8 @@ const inlineCss = async opt => {
     skippable: request =>
       options.skipThirdPartyRequests && !request.url().startsWith(basePath),
     browser: browser,
-    userAgent: options.userAgent
+    userAgent: options.userAgent,
+    ...options.minifyCss
   });
   const criticalCss = minimalcssResult.finalCss;
   const criticalCssSize = Buffer.byteLength(criticalCss, "utf8");


### PR DESCRIPTION
I think it's how things should work. I didn't find any docs references to minifyCss or how to use it. I perhaps it is a way. 

History:
I have had an invalid css and minimalcss failed, however, it was easily by adding the `"ignoreCSSErrors": true` to the config but react-snap has no way to do that. So I have made a PR that allows to specify the minimalcss config options with the reacts-snap minifyCss config option