### PR TITLE
Add exclude option (no new dependency added)

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ const defaultOptions = {
   destination: null,
   concurrency: 4,
   include: ["/"],
+  exclude: [],
   userAgent: "ReactSnap",
   // 4 params below will be refactored to one: `puppeteer: {}`
   // https://github.com/stereobooster/react-snap/issues/120

--- a/index.js
+++ b/index.js
@@ -19,7 +19,6 @@ const defaultOptions = {
   destination: null,
   concurrency: 4,
   include: ["/"],
-  exclude: [],
   userAgent: "ReactSnap",
   // 4 params below will be refactored to one: `puppeteer: {}`
   // https://github.com/stereobooster/react-snap/issues/120

--- a/src/puppeteer_utils.js
+++ b/src/puppeteer_utils.js
@@ -184,7 +184,10 @@ const crawl = async opt => {
     // Port can be null, therefore we need the null check
     const isOnAppPort = port && port.toString() === options.port.toString();
 
-    if (hostname === "localhost" && isOnAppPort && !uniqueUrls.has(newUrl) && !streamClosed) {
+    // Do not add excluded urls to the queue
+    const isExcluded = options.exclude.includes(newUrl)
+
+    if (hostname === "localhost" && isOnAppPort && !uniqueUrls.has(newUrl) && !streamClosed && !isExcluded) {
       uniqueUrls.add(newUrl);
       enqued++;
       queue.write(newUrl);

--- a/src/puppeteer_utils.js
+++ b/src/puppeteer_utils.js
@@ -185,7 +185,7 @@ const crawl = async opt => {
     const isOnAppPort = port && port.toString() === options.port.toString();
 
     // Do not add excluded urls to the queue
-    const isExcluded = options.exclude.includes(newUrl)
+    const isExcluded = options.exclude && options.exclude.includes(newUrl)
 
     if (hostname === "localhost" && isOnAppPort && !uniqueUrls.has(newUrl) && !streamClosed && !isExcluded) {
       uniqueUrls.add(newUrl);

--- a/tests/examples/other/exclude-url.html
+++ b/tests/examples/other/exclude-url.html
@@ -1,0 +1,13 @@
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+</head>
+
+<body>
+  <a href="/foo.html">Foo</a>
+  <a href="/bar.html">Bar</a>
+  <a href="/baz.html">Baz</a>
+</body>
+
+</html>

--- a/tests/run.test.js
+++ b/tests/run.test.js
@@ -589,6 +589,27 @@ describe("history.pushState two redirects to the same file", () => {
   });
 });
 
+describe("excludes urls in options.exclude array", () => {
+  const source = "tests/examples/other";
+  const include = ["/exclude-url.html"];
+
+  const exclude = ["http://localhost:45671/bar.html", "http://localhost:45671/baz.html"]
+  
+  const { fs, filesCreated, names } = mockFs();
+
+  beforeAll(() => snapRun(fs, { source, include, exclude, port: 45671 }));
+  test("should not crawl urls in exclude", () => {
+    expect(filesCreated()).toEqual(3);
+    expect(names()).toEqual(
+      expect.arrayContaining([
+        `/${source}/exclude-url.html`,
+        `/${source}/foo.html`,
+        `/${source}/404.html`,
+      ])
+    );
+  });
+});
+
 describe.skip("publicPath", () => {});
 
 describe.skip("skipThirdPartyRequests", () => {});


### PR DESCRIPTION
### Description
Main reason why I added this was because I was generating a static build for a simple site, but for some reason it crawls a url with a different domain (localhost with different port). I would try and investigate the localhost issue, but having an exclude option will cover future problems as well.

- Adding some simple logic to exclude specific URLs from crawl queue.
- Did not include `exclude` in the `defaultOptions` (not sure how to properly update the snapshot 🤷).
- Unit test

Feel free to close, but so far tests are good. I will use the forked version for my use case right now, but having it in the main repo would be nicer.

Cheers!
